### PR TITLE
Fix macOS build command in getting_started.rst

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -160,7 +160,7 @@ Step 4: Configure and Build the Targets
 .. code-block:: bash
 
    mkdir build && cd build
-   cmake /rl_tools -DCMAKE_BUILD_TYPE=Release -DRL_TOOLS_ENABLE_TARGETS=ON -DRL_TOOLS_BACKEND_ENABLE_OPENBLAS=ON
+   cmake .. -DCMAKE_BUILD_TYPE=Release -DRL_TOOLS_ENABLE_TARGETS=ON -DRL_TOOLS_BACKEND_ENABLE_OPENBLAS=ON
    cmake --build .
 
 


### PR DESCRIPTION
Fixing an error in the build path for macOS.

We are building from rl-tools/build so we need to run cmake from one folder up with `..`. This is similar to the learning-to-fly macOS instructions. 

current command leads to the following error:

`cmake /rl_tools -DCMAKE_BUILD_TYPE=Release -DRL_TOOLS_ENABLE_TARGETS=ON -DRL_TOOLS_BACKEND_ENABLE_ACCELERATE=ON`
->
> CMake Error: The source directory "/rl_tools" does not exist. Specify --help for usage, or press the help button on the CMake GUI.